### PR TITLE
Add open flag to parcel cli so that it opens the browser in dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "parcel public/index.html",
+    "start": "parcel public/index.html --open",
     "build": "parcel build public/index.html"
   },
   "dependencies": {


### PR DESCRIPTION
Adding the --open flag removes the need to manually open the browser and saves precious seconds of effort